### PR TITLE
Add coupon removal on partial payment

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -63,6 +63,8 @@ This plugin allows you to disable any payment gateway of WooCommerce based on mu
 
 &#9989; Restrict payment method by coupon code applied by customer
 
+&#9989; Automatically remove coupons when partial payment is selected
+
 &#9989; Disable COD when user select Different shipping address option during checkout
 
 &#9989; In a multi currency site you can disable payment method based on the currency selected by the customer

--- a/public/class-partial-payment-ui.php
+++ b/public/class-partial-payment-ui.php
@@ -22,6 +22,11 @@ class Pi_dpmw_partial_payment_ui{
         add_action('woocommerce_before_template_part', [$this, 'showPartialPaymentOption'], 10, 1);
 
         /**
+         * Remove any applied coupons when partial payment is selected
+         */
+        add_action( 'woocommerce_before_calculate_totals', [ $this, 'maybe_remove_coupons' ], 1 );
+
+        /**
          * This sets the main total of the checkout
          */
         add_filter( 'woocommerce_calculated_total', [$this, 'recalculate_price'], PHP_INT_MAX - 10, 2 );
@@ -450,6 +455,31 @@ class Pi_dpmw_partial_payment_ui{
         }
 
         return $url;
+    }
+
+    /**
+     * Remove applied coupons when partial payment is selected.
+     *
+     * @param WC_Cart $cart
+     */
+    function maybe_remove_coupons( $cart ) {
+        if ( ! Session::partialPaymentSelected() ) {
+            return;
+        }
+
+        if ( ! is_object( $cart ) ) {
+            return;
+        }
+
+        $applied = $cart->get_applied_coupons();
+
+        if ( empty( $applied ) ) {
+            return;
+        }
+
+        foreach ( $applied as $code ) {
+            $cart->remove_coupon( $code );
+        }
     }
 
     function hide_pay_link($actions, $order){


### PR DESCRIPTION
## Summary
- remove coupons automatically when partial payment is chosen
- document coupon removal behavior in README

## Testing
- `php -l public/class-partial-payment-ui.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f8a72eed48321bb8b6b3b8a56aa7f